### PR TITLE
feat: SalesHistoryView 추가 및 UserPurchaseHistoryView 수정

### DIFF
--- a/src/ui/MainFrame.java
+++ b/src/ui/MainFrame.java
@@ -32,6 +32,7 @@ public class MainFrame extends JFrame {
         mainPanel.add(new RegisterView(this), "RegisterView");
         mainPanel.add(new AdminMainView(this), "AdminMainView");
         mainPanel.add(new UserPurchaseHistoryView(this), "UserPurchaseHistoryView");
+        mainPanel.add(new SalesHistoryView(this), "SalesHistoryView");
 
         add(mainPanel, BorderLayout.CENTER);
 

--- a/src/ui/UserPurchaseHistoryView.java
+++ b/src/ui/UserPurchaseHistoryView.java
@@ -49,9 +49,9 @@ public class UserPurchaseHistoryView extends JPanel {
         Object[][] data = new Object[purchases.size()][3];
 
         for (int i = 0; i < purchases.size(); i++) {
-            data[i][0] = purchases.get(i).getSaleId();
+            data[i][0] = purchases.get(i).getId();
             data[i][1] = purchases.get(i).getPhoneId();
-            data[i][2] = purchases.get(i).getSaleDate();
+            data[i][2] = purchases.get(i).getSaleTime();
         }
 
         return data;

--- a/test/app/dao/UserDaoTest.java
+++ b/test/app/dao/UserDaoTest.java
@@ -1,0 +1,76 @@
+package app.dao;
+
+import common.DBManager;
+import dao.UserDao;
+import dto.User;
+import org.junit.jupiter.api.*;
+
+import java.sql.Connection;
+import java.sql.SQLException;
+import java.sql.Timestamp;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+public class UserDaoTest {
+    private UserDao userDao;
+    private Connection con;
+
+    @BeforeAll
+    void setUp() throws SQLException {
+        userDao = new UserDao();
+        con = DBManager.getConnection();
+        con.setAutoCommit(false); // 트랜잭션 시작(자동 커밋 비활성화)
+    }
+
+    @AfterAll
+    void tearDown() throws SQLException {
+        if (con != null) {
+            con.rollback();
+            con.close();
+        }
+    }
+
+    @Test
+    @DisplayName("회원 가입 성공")
+    void createUser_Success() {
+        // Given
+        User user = new User(0, "홍길동", "010-1234-5678", "test@example.com", "password123", new Timestamp(System.currentTimeMillis()), "user");
+
+        // When
+        int res = userDao.createUser(user);
+
+        // Then
+        assertEquals(1, res);
+    }
+
+    @Test
+    @DisplayName("이메일로 사용자 조회 성공")
+    void getUserByEmail_Success() {
+        // Given
+        String email = "test@example.com";
+
+        // Then
+        User user = userDao.getUserByEmail(email);
+
+        // When
+        assertNotNull(user);
+        assertEquals("test@example.com", user.getEmail());
+    }
+
+    @Test
+    @DisplayName("전체 사용자 목록 조회 성공")
+    void getAllUsers_Success() {
+        // Given
+        User user = new User(0, "김철수", "010-5678-1234", "chulsoo@example.com", "password456", new Timestamp(System.currentTimeMillis()), "user");
+        userDao.createUser(user);
+
+        // When
+        List<User> users = userDao.getAllUsers();
+
+        // Then
+        assertNotNull(users);
+        assertFalse(users.isEmpty());
+    }
+}


### PR DESCRIPTION
- SalesHistoryView 추가 (관리자가 전체 판매 내역을 확인할 수 있도록 구현)
- MainFrame에서 SalesHistoryView 등록
  - "mainPanel.add(new SalesHistoryView(this), "SalesHistoryView");" 추가하여 화면 전환 가능하도록 설정
- UserPurchaseHistoryView에서 구매 내역 데이터 수정
  - 기존: getSaleId(), getPhoneId(), getSaleDate() 사용
  - 변경: getId(), getPhoneId(), getSaleTime() 사용 (DTO 필드명 변경에 맞춰 수정)