### PR TITLE
feat: 비밀번호 해싱 기능 추가 및 회원가입 연동 수정

### DIFF
--- a/src/common/PasswordUtil.java
+++ b/src/common/PasswordUtil.java
@@ -1,0 +1,15 @@
+package common;
+
+import org.mindrot.jbcrypt.BCrypt;
+
+public class PasswordUtil {
+    // 비밀번호 해싱
+    public static String hashPassword(String plainTextPassword) {
+        return BCrypt.hashpw(plainTextPassword, BCrypt.gensalt());
+    }
+
+    // 비밀번호 검증
+    public static boolean checkPassword(String plainTextPassword, String hashedPassword) {
+        return BCrypt.checkpw(plainTextPassword, hashedPassword);
+    }
+}

--- a/src/dao/UserDao.java
+++ b/src/dao/UserDao.java
@@ -1,6 +1,7 @@
 package dao;
 
 import common.DBManager;
+import common.PasswordUtil;
 import dto.User;
 
 import java.sql.Connection;
@@ -26,7 +27,7 @@ public class UserDao {
             pstmt.setString(1, user.getUserName());
             pstmt.setString(2, user.getContact());
             pstmt.setString(3, user.getEmail());
-            pstmt.setString(4, user.getPassword());
+            pstmt.setString(4, PasswordUtil.hashPassword(user.getPassword())); // 해싱된 비밀번호 저장
             pstmt.setString(5, user.getRole());
 
             res = pstmt.executeUpdate();

--- a/src/ui/LoginView.java
+++ b/src/ui/LoginView.java
@@ -1,5 +1,6 @@
 package ui;
 
+import common.PasswordUtil;
 import dao.UserDao;
 import dto.User;
 import ui.MainFrame;
@@ -70,7 +71,7 @@ public class LoginView extends JPanel {
 
         User user = userDao.getUserByEmail(email);
 
-        if (user == null || !user.getPassword().equals(password)) {
+        if (user == null || !PasswordUtil.checkPassword(password, user.getPassword())) { // 해싱된 비밀번호 검증
             JOptionPane.showMessageDialog(this, "이메일 또는 비밀번호가 잘못되었습니다.", "로그인 실패", JOptionPane.ERROR_MESSAGE);
             return;
         }

--- a/src/ui/RegisterView.java
+++ b/src/ui/RegisterView.java
@@ -1,5 +1,6 @@
 package ui;
 
+import common.PasswordUtil;
 import dao.UserDao;
 import dto.User;
 
@@ -92,7 +93,11 @@ public class RegisterView extends JPanel {
             return;
         }
 
-        User newUser = new User(0, name, contact, email, password, new Timestamp(System.currentTimeMillis()), "user");
+        // 비밀번호 해싱 추가
+        String hashedPassword = PasswordUtil.hashPassword(password);
+
+        // 해싱된 비밀번호 저장
+        User newUser = new User(0, name, contact, email, hashedPassword, new Timestamp(System.currentTimeMillis()), "user");
         int result = userDao.createUser(newUser);
 
         if (result > 0) {

--- a/test/app/common/BCryptTest.java
+++ b/test/app/common/BCryptTest.java
@@ -1,0 +1,23 @@
+package app.common;
+
+import common.PasswordUtil;
+import org.junit.jupiter.api.Test;
+import static org.junit.jupiter.api.Assertions.*;
+
+public class BCryptTest {
+
+    @Test
+    public void testPasswordHashingAndVerification() {
+        // Given (테스트용 비밀번호)
+        String rawPassword = "securePassword123";
+
+        // When (비밀번호 해싱)
+        String hashedPassword = PasswordUtil.hashPassword(rawPassword);
+
+        // Then (비밀번호 검증)
+        assertNotNull(hashedPassword, "해싱된 비밀번호가 null이면 안 됩니다.");
+        assertNotEquals(rawPassword, hashedPassword, "해싱된 비밀번호는 원본과 달라야 합니다.");
+        assertTrue(PasswordUtil.checkPassword(rawPassword, hashedPassword), "비밀번호 검증이 실패했습니다.");
+        assertFalse(PasswordUtil.checkPassword("wrongPassword", hashedPassword), "잘못된 비밀번호가 검증에 성공하면 안 됩니다.");
+    }
+}


### PR DESCRIPTION
- BCrypt를 활용한 비밀번호 해싱 기능 추가
	- PasswordUtil 클래스 추가 (hashPassword(), checkPassword() 메서드 포함)
	- BCryptTest 추가 (비밀번호 해싱 및 검증 테스트)
- 로그인 및 회원가입 로직 수정
	- LoginView: 입력된 비밀번호를 PasswordUtil.checkPassword()로 검증하도록 수정
  - RegisterView: 회원가입 시 PasswordUtil.hashPassword()를 사용하여 비밀번호를 해싱 후 저장
	- UserDao: 기존 평문 비밀번호 저장 로직을 해싱된 비밀번호 저장 방식으로 변경
- 보완 사항
	- 관리자 계정은 비밀번호 암호화 적용 제외
	- 회원가입 후 암호화된 비밀번호가 DB에 저장되는지 확인 필요